### PR TITLE
hotfix: remove host directive causing robots.txt redirect loop

### DIFF
--- a/app/robots.ts
+++ b/app/robots.ts
@@ -10,6 +10,5 @@ export default function robots() {
       },
     ],
     sitemap: `${baseUrl}/sitemap.xml`,
-    host: baseUrl,
   };
 }


### PR DESCRIPTION
- Remove host: baseUrl from robots.ts (production fix)
- Fixes ERR_TOO_MANY_REDIRECTS on /robots.txt
- Tested and working on dev environment
- Critical SEO fix for Google Search Console