### PR TITLE
Update member count to 40,000

### DIFF
--- a/app/about/about.mdx
+++ b/app/about/about.mdx
@@ -1,5 +1,5 @@
 Hi! I'm Sam, Co-Founder and CEO of [Pickup Music](https://pickupmusic.com), an independent education technology company based in Los Angeles.
 
-I started Pickup Music while studying jazz guitar in New York City. From 2015-2018, I grew Pickup Music to become the leading online community of musicians with over a million Instagram followers. It has since evolved into the top provider of music education with over 30,000 members.
+I started Pickup Music while studying jazz guitar in New York City. From 2015-2018, I grew Pickup Music to become the leading online community of musicians with over a million Instagram followers. It has since evolved into the top provider of music education with over 40,000 members.
 
 I lead the content, curriculum, and engineering teams at Pickup Music.


### PR DESCRIPTION
## Summary

Updates the Pickup Music member count from 30,000 to 40,000 in the home/about bio (`app/about/about.mdx`, rendered on both the home page and the About page).

## Notes
- The Canterbury interview post still references "30,000 students" — left unchanged since it's inside a quoted interview transcript.
- Pre-commit hooks (Prettier, ESLint, `tsc`) pass clean.