### PR TITLE
Fix Cloudflare Pages build + enforce commit attribution rules

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,4 @@
+if grep -qiE 'co-authored-by:.*(claude|anthropic)|generated with.*claude' "$1"; then
+  echo "✖ Commit message contains Claude/AI attribution. Remove it (see CLAUDE.md)." >&2
+  exit 1
+fi

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
## Changes

- **`.npmrc` with `legacy-peer-deps=true`**: Cloudflare Pages builds broke on every deploy because the build command (`npx @cloudflare/next-on-pages@1`) hits an npm ERESOLVE conflict: the newly released `wrangler@4.118.0` wants `@cloudflare/workers-types` v5 while `next-on-pages` wants v4. This tells npm to tolerate the optional-peer conflict, restoring deploys.
- **`.husky/commit-msg` hook**: rejects any commit message containing Claude/Anthropic co-author or attribution lines, so they can never land in history again.