### PR TITLE
Make README copyright year-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Personal website built with Next.js using this [blog template](https://vercel.co
 
 The source code is provided as-is for reference purposes.
 
-© 2025 Sam Blakelock.
+© Sam Blakelock.


### PR DESCRIPTION
Drops the hardcoded year from the README copyright line so it never goes stale.